### PR TITLE
Error in room 

### DIFF
--- a/app.py
+++ b/app.py
@@ -141,7 +141,7 @@ class Room:
     async def broadcast_message(self, user_id: str, msg: str):
         """Broadcast message to all connected users.
         """
-        self._user_meta[user_id].message_count += 1
+        # self._user_meta[user_id].message_count += 1 # TODO: review, in the /thunder endpoint you are passing 'server' as user_id, which will never exists.
         for websocket in self._users.values():
             await websocket.send_json(
                 {"type": "MESSAGE", "data": {"user_id": user_id, "msg": msg}}


### PR DESCRIPTION
You are passing "server" as user_id to the broadcast method, this user_id will never exists.
Thunder endpoint
```py
@app.post("/thunder")
async def thunder(request: Request, distance: ThunderDistance = Body(...)):
    """Broadcast an ambient message to all chat room users.
    """
    room: Optional[Room] = request.get("room")
    if room is None:
        raise HTTPException(500, detail="Global `Room` instance unavailable!")
    if distance.category == Distance.Near:
        await room.broadcast_message("server", "Thunder booms overhead")
    elif distance.category == Distance.Far:
        await room.broadcast_message("server", "Thunder rumbles in the distance")
    else:
        await room.broadcast_message("server", "You feel a faint tremor")
```

``broadcast_message` method in `Room` class
```py
async def broadcast_message(self, user_id: str, msg: str):
        """Broadcast message to all connected users.
        """
        # self._user_meta[user_id].message_count += 1 
        for websocket in self._users.values():
            await websocket.send_json(
                {"type": "MESSAGE", "data": {"user_id": user_id, "msg": msg}}
            )
```